### PR TITLE
fix mobile alignment of record color swatches

### DIFF
--- a/src/lib/components/form/question.svelte
+++ b/src/lib/components/form/question.svelte
@@ -149,6 +149,11 @@
         flex-wrap: wrap;
         gap: 10px;
     }
+    /* Image-swatch questions: center the row so the orphan
+       buttons in the last row don't drift left on mobile. */
+    .question-buttons-container:has(img) {
+        justify-content: center;
+    }
     button {
         background: var(--gn-paper);
         color: var(--gn-ink);
@@ -176,13 +181,16 @@
     button.isSelected:hover {
         background: #000;
     }
-    /* Image swatches: drop the ring + chip styling so the vinyl reads on its own. */
+    /* Image swatches: drop the ring + chip styling so the vinyl reads on its own.
+       Fix the width so every swatch occupies the same footprint regardless of
+       label length — keeps images aligned across rows on mobile. */
     button:has(img) {
         background: transparent;
         box-shadow: none;
         padding: 6px;
         border-radius: var(--gn-r-sm);
         min-width: 0;
+        width: 122px;
     }
     button:has(img):hover:not(:disabled) {
         background: var(--gn-n-100);
@@ -193,9 +201,10 @@
         box-shadow: inset 0 0 0 2px var(--gn-ink);
     }
     img {
-        width: 100%;
-        max-width: 110px;
+        width: 110px;
+        height: 110px;
         display: block;
         border-radius: var(--gn-r-sm);
+        object-fit: contain;
     }
 </style>


### PR DESCRIPTION
## Summary
- Lock image-swatch buttons to a fixed 122px footprint and images to 110×110, so swatches no longer take width from label text
- Center the wrapped row (`justify-content: center` on `:has(img)` containers) so orphan swatches in the last row don't drift left on mobile

## Test plan
- [ ] On mobile viewport, verify the record color swatches form even rows
- [ ] Verify the last partial row centers rather than left-aligning
- [ ] Verify all record images are the same size regardless of label length
- [ ] Verify desktop layout still looks correct

https://claude.ai/code/session_01GNWjvsVh4GZUDqZnXH5Szz

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNWjvsVh4GZUDqZnXH5Szz)_